### PR TITLE
chore: ignore OpenClaw autodev lock artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ IDENTITY.md
 SOUL.md
 TOOLS.md
 USER.md
+
+# OpenClaw automation runtime locks (do not commit)
+talkecho-autodev.lock*


### PR DESCRIPTION
Prevents OpenClaw runtime lock files from being committed again.

- Add `talkecho-autodev.lock*` to `.gitignore`.