### PR TITLE
Dev Space: persist provider variables per provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talkecho",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "talkecho",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "GPL-3.0",
       "dependencies": {
         "@bany/curl-to-json": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "talkecho",
   "private": false,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TalkEcho - an invisible desktop subtitle & translation copilot forked from Pluely.",
   "author": {
     "name": "Ruizhang Zhou",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "talkecho"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "talkecho"
-version = "0.1.7"
+version = "0.1.8"
 description = "TalkEcho - invisible real-time meeting captions & translation (forked from Pluely)."
 authors = ["Ruizhang Zhou <ruizhang.zhou@mail.com>"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TalkEcho",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "com.talkecho.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,6 +10,8 @@ export const STORAGE_KEYS = {
   CUSTOM_SPEECH_PROVIDERS: "curl_custom_speech_providers",
   SELECTED_AI_PROVIDER: "curl_selected_ai_provider",
   SELECTED_STT_PROVIDER: "curl_selected_stt_provider",
+  AI_PROVIDER_VARIABLES_BY_ID: "curl_ai_provider_variables_by_id",
+  STT_PROVIDER_VARIABLES_BY_ID: "curl_stt_provider_variables_by_id",
   SYSTEM_AUDIO_CONTEXT: "system_audio_context",
   SYSTEM_AUDIO_QUICK_ACTIONS: "system_audio_quick_actions",
   SYSTEM_AUDIO_INCLUDE_MICROPHONE: "system_audio_include_microphone",

--- a/src/contexts/app.context.tsx
+++ b/src/contexts/app.context.tsx
@@ -66,6 +66,55 @@ const validateAndProcessCurlProviders = (
   }
 };
 
+type ProviderVariables = Record<string, string>;
+type ProviderVariablesById = Record<string, ProviderVariables>;
+
+const parseProviderVariablesById = (raw: string | null): ProviderVariablesById => {
+  if (!raw) return {};
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const result: ProviderVariablesById = {};
+    for (const [providerId, variables] of Object.entries(
+      parsed as Record<string, unknown>
+    )) {
+      if (!providerId || typeof providerId !== "string") continue;
+      if (!variables || typeof variables !== "object" || Array.isArray(variables))
+        continue;
+
+      const cleanVariables: ProviderVariables = {};
+      for (const [key, value] of Object.entries(
+        variables as Record<string, unknown>
+      )) {
+        if (!key || typeof key !== "string") continue;
+        if (typeof value === "string") {
+          cleanVariables[key] = value;
+        }
+      }
+      result[providerId] = cleanVariables;
+    }
+
+    return result;
+  } catch {
+    return {};
+  }
+};
+
+const getProviderVariablesById = (storageKey: string): ProviderVariablesById => {
+  return parseProviderVariablesById(safeLocalStorage.getItem(storageKey));
+};
+
+const setProviderVariablesById = (
+  storageKey: string,
+  variablesById: ProviderVariablesById
+) => {
+  safeLocalStorage.setItem(storageKey, JSON.stringify(variablesById));
+};
+
 // Create the context
 const AppContext = createContext<IContextType | undefined>(undefined);
 
@@ -488,11 +537,29 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    setSelectedAIProvider((prev) => ({
-      ...prev,
-      provider,
-      variables,
-    }));
+    const isSwitching = provider !== selectedAIProvider.provider;
+    const variablesByIdKey = STORAGE_KEYS.AI_PROVIDER_VARIABLES_BY_ID;
+
+    let variablesById = getProviderVariablesById(variablesByIdKey);
+
+    // Save current provider variables before switching
+    if (isSwitching && selectedAIProvider.provider) {
+      variablesById[selectedAIProvider.provider] = selectedAIProvider.variables;
+    }
+
+    const shouldRestore =
+      isSwitching && Object.keys(variables || {}).length === 0;
+    const nextVariables: Record<string, string> = shouldRestore
+      ? variablesById[provider] || {}
+      : variables;
+
+    // Persist the latest variables for the selected provider
+    if (provider) {
+      variablesById[provider] = nextVariables;
+      setProviderVariablesById(variablesByIdKey, variablesById);
+    }
+
+    setSelectedAIProvider((prev) => ({ ...prev, provider, variables: nextVariables }));
   };
 
   // Setter for selected STT with validation
@@ -508,7 +575,29 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    setSelectedSttProvider((prev) => ({ ...prev, provider, variables }));
+    const isSwitching = provider !== selectedSttProvider.provider;
+    const variablesByIdKey = STORAGE_KEYS.STT_PROVIDER_VARIABLES_BY_ID;
+
+    let variablesById = getProviderVariablesById(variablesByIdKey);
+
+    // Save current provider variables before switching
+    if (isSwitching && selectedSttProvider.provider) {
+      variablesById[selectedSttProvider.provider] = selectedSttProvider.variables;
+    }
+
+    const shouldRestore =
+      isSwitching && Object.keys(variables || {}).length === 0;
+    const nextVariables: Record<string, string> = shouldRestore
+      ? variablesById[provider] || {}
+      : variables;
+
+    // Persist the latest variables for the selected provider
+    if (provider) {
+      variablesById[provider] = nextVariables;
+      setProviderVariablesById(variablesByIdKey, variablesById);
+    }
+
+    setSelectedSttProvider((prev) => ({ ...prev, provider, variables: nextVariables }));
   };
 
   // Toggle handlers

--- a/src/contexts/app.context.tsx
+++ b/src/contexts/app.context.tsx
@@ -69,38 +69,55 @@ const validateAndProcessCurlProviders = (
 type ProviderVariables = Record<string, string>;
 type ProviderVariablesById = Record<string, ProviderVariables>;
 
+const isPrototypePollutionKey = (key: string) => {
+  return key === "__proto__" || key === "constructor" || key === "prototype";
+};
+
+const createNullProtoObject = <T extends Record<string, any>>() => {
+  return Object.create(null) as T;
+};
+
+const sanitizeProviderVariables = (variables: unknown): ProviderVariables => {
+  if (!variables || typeof variables !== "object" || Array.isArray(variables)) {
+    return createNullProtoObject<ProviderVariables>();
+  }
+
+  const clean = createNullProtoObject<ProviderVariables>();
+  for (const [key, value] of Object.entries(variables as Record<string, unknown>)) {
+    if (!key || typeof key !== "string" || isPrototypePollutionKey(key)) continue;
+    if (typeof value === "string") {
+      clean[key] = value;
+    }
+  }
+  return clean;
+};
+
+const sanitizeProviderVariablesById = (input: unknown): ProviderVariablesById => {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return createNullProtoObject<ProviderVariablesById>();
+  }
+
+  const result = createNullProtoObject<ProviderVariablesById>();
+  for (const [providerId, variables] of Object.entries(
+    input as Record<string, unknown>
+  )) {
+    if (!providerId || typeof providerId !== "string") continue;
+    if (isPrototypePollutionKey(providerId)) continue;
+
+    result[providerId] = sanitizeProviderVariables(variables);
+  }
+
+  return result;
+};
+
 const parseProviderVariablesById = (raw: string | null): ProviderVariablesById => {
-  if (!raw) return {};
+  if (!raw) return createNullProtoObject<ProviderVariablesById>();
 
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {};
-    }
-
-    const result: ProviderVariablesById = {};
-    for (const [providerId, variables] of Object.entries(
-      parsed as Record<string, unknown>
-    )) {
-      if (!providerId || typeof providerId !== "string") continue;
-      if (!variables || typeof variables !== "object" || Array.isArray(variables))
-        continue;
-
-      const cleanVariables: ProviderVariables = {};
-      for (const [key, value] of Object.entries(
-        variables as Record<string, unknown>
-      )) {
-        if (!key || typeof key !== "string") continue;
-        if (typeof value === "string") {
-          cleanVariables[key] = value;
-        }
-      }
-      result[providerId] = cleanVariables;
-    }
-
-    return result;
+    return sanitizeProviderVariablesById(parsed);
   } catch {
-    return {};
+    return createNullProtoObject<ProviderVariablesById>();
   }
 };
 
@@ -112,7 +129,10 @@ const setProviderVariablesById = (
   storageKey: string,
   variablesById: ProviderVariablesById
 ) => {
-  safeLocalStorage.setItem(storageKey, JSON.stringify(variablesById));
+  safeLocalStorage.setItem(
+    storageKey,
+    JSON.stringify(sanitizeProviderVariablesById(variablesById))
+  );
 };
 
 // Create the context
@@ -549,9 +569,9 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
     const shouldRestore =
       isSwitching && Object.keys(variables || {}).length === 0;
-    const nextVariables: Record<string, string> = shouldRestore
-      ? variablesById[provider] || {}
-      : variables;
+    const nextVariables = sanitizeProviderVariables(
+      shouldRestore ? variablesById[provider] : variables
+    );
 
     // Persist the latest variables for the selected provider
     if (provider) {
@@ -587,9 +607,9 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
     const shouldRestore =
       isSwitching && Object.keys(variables || {}).length === 0;
-    const nextVariables: Record<string, string> = shouldRestore
-      ? variablesById[provider] || {}
-      : variables;
+    const nextVariables = sanitizeProviderVariables(
+      shouldRestore ? variablesById[provider] : variables
+    );
 
     // Persist the latest variables for the selected provider
     if (provider) {

--- a/src/hooks/useCustomProvider.ts
+++ b/src/hooks/useCustomProvider.ts
@@ -34,7 +34,7 @@ export function useCustomAiProviders() {
       ...provider,
     });
     setEditingProvider(providerId);
-    setShowForm(!showForm);
+    setShowForm(true);
     setErrors({});
   };
 

--- a/src/hooks/useCustomSttProviders.ts
+++ b/src/hooks/useCustomSttProviders.ts
@@ -34,7 +34,7 @@ export function useCustomSttProviders() {
       ...provider,
     });
     setEditingProvider(providerId);
-    setShowForm(!showForm);
+    setShowForm(true);
     setErrors({});
   };
 

--- a/src/pages/dev/components/ai-configs/CreateEditProvider.tsx
+++ b/src/pages/dev/components/ai-configs/CreateEditProvider.tsx
@@ -27,6 +27,7 @@ export const CreateEditProvider = ({
     showForm,
     setShowForm,
     editingProvider,
+    setEditingProvider,
     formData,
     setFormData,
     errors,
@@ -35,13 +36,25 @@ export const CreateEditProvider = ({
     handleAutoFill,
   } = hookInstance;
 
+  const resetForm = () => {
+    setEditingProvider(null);
+    setFormData({
+      id: "",
+      streaming: false,
+      responseContentPath: "",
+      isCustom: true,
+      curl: "",
+    });
+    setErrors({});
+  };
+
   return (
     <>
       {!showForm ? (
         <Button
           onClick={() => {
+            resetForm();
             setShowForm(true);
-            setErrors({});
           }}
           variant="outline"
           className="w-full h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
@@ -251,7 +264,10 @@ export const CreateEditProvider = ({
           <div className="flex justify-end gap-2 -mt-3">
             <Button
               variant="outline"
-              onClick={() => setShowForm(!showForm)}
+              onClick={() => {
+                resetForm();
+                setShowForm(false);
+              }}
               className="h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
             >
               Cancel

--- a/src/pages/dev/components/stt-configs/CreateEditProvider.tsx
+++ b/src/pages/dev/components/stt-configs/CreateEditProvider.tsx
@@ -27,6 +27,7 @@ export const CreateEditProvider = ({
     showForm,
     setShowForm,
     editingProvider,
+    setEditingProvider,
     formData,
     setFormData,
     errors,
@@ -35,13 +36,25 @@ export const CreateEditProvider = ({
     handleAutoFill,
   } = hookInstance;
 
+  const resetForm = () => {
+    setEditingProvider(null);
+    setFormData({
+      id: "",
+      streaming: false,
+      responseContentPath: "",
+      isCustom: true,
+      curl: "",
+    });
+    setErrors({});
+  };
+
   return (
     <>
       {!showForm ? (
         <Button
           onClick={() => {
+            resetForm();
             setShowForm(true);
-            setErrors({});
           }}
           variant="outline"
           className="w-full h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
@@ -216,7 +229,10 @@ export const CreateEditProvider = ({
           <div className="flex justify-end gap-2 -mt-3">
             <Button
               variant="outline"
-              onClick={() => setShowForm(!showForm)}
+              onClick={() => {
+                resetForm();
+                setShowForm(false);
+              }}
               className="h-11 border-1 border-input/50 focus:border-primary/50 transition-colors"
             >
               Cancel


### PR DESCRIPTION
Closes #55\n\nWhat\n- Fix Dev Space Custom Provider Add/Edit form state so Add no longer accidentally updates an edited provider after Cancel.\n- Persist AI/STT provider variables per provider-id (switching providers restores last-used variables instead of wiping).\n\nNotes\n- Adds local-only storage maps: curl_ai_provider_variables_by_id / curl_stt_provider_variables_by_id.\n\nTesting\n- npm run build\n- cargo check (src-tauri)